### PR TITLE
Detect OS, add tests, use common.js - Closes #1 and #3

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,26 @@
 const getPrivateBrowsingName = () => {
   const ua = navigator && navigator.userAgent;
-  const dict = [
+
+  const osDict = [
+    {
+      os: 'iOS',
+      regex: /iP(hone|od|ad)/
+    },
+    {
+      os: 'Linux',
+      regex: /(Linux)|(X11)/
+    },
+    {
+      os: 'Mac OS',
+      regex: /(Mac_PowerPC)|(Macintosh)/
+    },
+    {
+      os: 'Windows',
+      regex: /Win/
+    }
+  ];
+
+  const browserDict = [
     {
       browser: 'edge',
       mode: 'InPrivate Browsing',
@@ -67,14 +87,41 @@ const getPrivateBrowsingName = () => {
     },
   ];
 
-  for (let i = 0, count = dict.length; i < count; i++) {
-    const { regex } = dict[i];
-    const match = regex.exec(ua);
-    if (match) {
-      return dict[i];
+  const lookup = (dict, str) => {
+    for (let i = 0, count = dict.length; i < count; i++) {
+      const { regex } = dict[i];
+      const match = regex.exec(str);
+      if (match) {
+        return dict[i];
+      }
     }
+    return null;
   }
-  return null;
+
+  const getOs = (str) => {
+    const result = lookup(osDict, str);
+    return result && result.os || null;
+  }
+
+  const getBrowser = (str) => {
+    return lookup(browserDict, str);
+  }
+
+  const os = getOs(ua);
+  const browser = getBrowser(ua);
+
+  let detectedMethod = null;
+  if (os === 'Windows' || os === 'Linux') {
+    detectedMethod = browser.windowsMethod;
+  } else if (os === 'Mac OS' || os === 'iOS') {
+    detectedMethod = browser.macMethod;
+  }
+
+  return browser && {
+    ...browser,
+    detectedMethod,
+  } || null;
+
 }
 
-export default getPrivateBrowsingName;
+module.exports = getPrivateBrowsingName;

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "get-private-browsing-name",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -16,5 +16,13 @@
   "homepage": "https://github.com/taitems/get-private-browsing-name",
   "author": "Tait Brown <taitbrown@gmail.com>",
   "license": "MIT",
-  "keywords": ["incognito","private browsing","inprivate"]
+  "keywords": [
+    "incognito",
+    "private browsing",
+    "inprivate"
+  ],
+  "devDependencies": {
+    "jest": "^25.1.0",
+    "jest-useragent-mock": "^0.0.3"
+  }
 }


### PR DESCRIPTION
- Detect OS so can return `detectedMethod` for user
- Add jest for tests
- Use common.js module.exports instead of export default